### PR TITLE
Add test coverage reporting

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+plugins = Cython.Coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,6 @@ python:
   - "2.7"
   - "3.4"
   - "3.5"
-install: pip install Cython pytest
+install: pip install Cython pytest pytest-cov coveralls
 script: make test
+after_success: coveralls

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,12 @@ build:
 	cython duktape.pyx
 	python setup.py build_ext --inplace
 
-test: build
-	py.test -xv
+buildtest:
+	cython -X linetrace=True duktape.pyx
+	CYTHON_TRACE=1 python setup.py build_ext --inplace
+
+test: buildtest
+	py.test -xv --cov=duktape.pyx
 
 clean:
 	rm -rf build/ duktape.c duktape*.so

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,16 @@
+import os
 import sys
 from distutils.core import setup,Extension
 from Cython.Build import cythonize
 
+if os.environ.get("CYTHON_TRACE"):
+    MACROS = [("CYTHON_TRACE", 1)]
+else:
+    MACROS = []
+
 duk_c=Extension(
   'duktape',
+  define_macros=MACROS,
   sources=[
     'duktape.pyx',
     'duktape_c/duktape.c',


### PR DESCRIPTION
See: https://coveralls.io/github/paltman/duktape-py

Once and if this is merged upstream, badges can be added for the canonical repo.